### PR TITLE
Fixed a small typo to use the domain classifier

### DIFF
--- a/helpers/_models.py
+++ b/helpers/_models.py
@@ -52,7 +52,7 @@ def get_domain_classifier(settings):
     :rtype: torch.nn.Module
     """
     return _get_classifier(
-        classifier_type='labels',
+        classifier_type='domain',
         input_dim=settings['models']['domain_classifier']['input_dim'],
         output_classes=settings['models']['domain_classifier']['classes'],
         use_pre_trained=False).to(


### PR DESCRIPTION
Hi, I changed one row of the file helpers/_models.py to use the actual domain classifier for the discriminator and not the label classifier.